### PR TITLE
Use logo.href instead of logoHref

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -2,9 +2,9 @@
   "name": "Webapp.io Documentation",
   "logo": {
     "light": "/logo/light.svg",
-    "dark": "/logo/dark.svg"
+    "dark": "/logo/dark.svg",
+    "href": "https://webapp.io"
   },
-  "logoHref": "https://webapp.io",
   "favicon": "/favicon.png",
   "colors": {
     "primary": "#1038C7",
@@ -45,10 +45,7 @@
   "navigation": [
     {
       "group": "Home",
-      "pages": [
-        "introduction",
-        "why-webapp"
-      ]
+      "pages": ["introduction", "why-webapp"]
     },
     {
       "group": "Layerfile Reference",
@@ -163,7 +160,7 @@
   },
   "analytics": {
     "mixpanel": {
-        "projectToken": "9216fddb2a6d3f348c9d9e149ef830ba"
+      "projectToken": "9216fddb2a6d3f348c9d9e149ef830ba"
     }
   }
 }


### PR DESCRIPTION
Mintlify is changing the logoHref syntax to exist inside the `logo` config. This PR moves it for you!

We are also renaming `mint.config.json` to `mint.json`.

Other changes were caused by prettier running automatically.