### PR TITLE
Docs for webapp.io hosting & deployment

### DIFF
--- a/docs/hosting/features-and-comparables.mdx
+++ b/docs/hosting/features-and-comparables.mdx
@@ -1,0 +1,30 @@
+---
+title: "Features and Comparables"
+description: "Deploy your project with webapp.io's virtual machines"
+---
+
+
+## Features
+
+- Available for 750 hours/month
+- Custom Domains (including wildcard domains)
+- Quick Wake-ups (A fast coldstart experience)
+- Free SSL and Automated Certificate Management for TLS
+- Debugging Terminal
+- Automated Preview Environments
+- Virtual Machine Analytics (CPU, Disk, Memory)
+- Built-in CI/CD
+- <a href="/api-docs/setup">API</a> for CI Jobs & Layerfile Runners
+- Integration for GitHub, GitLab, and BitBucket
+- Slack Notifications
+
+
+## Comparables
+
+| Provider | Resource Name                          |
+| -------- | ------------------------------------- |
+| webapp.io     | Virtual Machines (Layerfile Runners)                |
+| Heroku      | Dyno                          |
+| Render   | Instance of a Render service |
+| AWS   | Ec2 Micro Instance/Elastic Beanstalk |
+| GCP   | Google Compute Engine/Google App Engine |

--- a/docs/hosting/free-hosting.mdx
+++ b/docs/hosting/free-hosting.mdx
@@ -1,0 +1,16 @@
+---
+title: "Free Hosting"
+description: "Deploy your project with webapp.io's virtual machines"
+---
+
+## Free Virtual Machines
+
+Webapp.io gives you access to free virtual machines that you can use to deploy a custom application on a custom domain. 
+
+Our VM's automatically hibernate after 30 minutes of inactivity, but with our proprietary snapshotting technology, we are able to wake up our VM's so the response delay is less than a few seconds.
+
+Our virtual machines are available for 750 hours a month (which spans an entire month). Webapp.io monitors usage, including the number of virtual machines deployed, to prevent spam and overload on the system. 
+
+<Warning>
+If you are misusing the virtual machines, webapp.io will ban you from the system permanently.
+</Warning>

--- a/docs/hosting/get-started.mdx
+++ b/docs/hosting/get-started.mdx
@@ -1,0 +1,66 @@
+---
+title: "Get Started"
+description: "Deploy your project with webapp.io's virtual machines"
+---
+
+Once you've signed up for webapp.io and installed webapp.io on your GitHub repository, you can try out our hosting option with one of our example projects or you can deploy your own code.
+
+<Note>
+It's easier to allow access to all repositories when connecting to GitHub. If not, please remember to give GitHub access to each new repository you create for webapp.io.
+</Note>
+
+
+## Add a Custom Domain
+
+Before deploying your project, make sure to add a custom domain to your webapp.io account. 
+
+To add a domain, check out our docs on <a href="/advanced-workflows/routing">routing</a>.
+
+## Example Projects
+
+Get started by following one of our example guides below. After completing the guide and deploying your application with a Layerfile, add a Custom Domain, and click on the "Deploy" button.
+
+- <a href="/examples/angular">Angular</a>
+- <a href="/examples/django">Django</a>
+- <a href="/examples/docker-compose">Docker Compose</a>
+- <a href="/examples/docker">Docker</a>
+- <a href="/examples/kubernetes">Kubernetes</a>
+- <a href="/examples/laravel">Laravel</a>
+- <a href="/examples/node">Node JS</a>
+- <a href="/examples/rails">Rails</a>
+- <a href="/examples/react">React</a>
+- <a href="/examples/something-else">Generic (HTML)</a>
+
+
+## Your own Code
+
+1. Create a Layerfile for your project
+2. Commit your Layerfile to your repository
+3. Deploy to your custom domain
+
+### Create a Layerfile for your project
+
+A Layerfile is a set of instructions that tell webapp.io how to build and run your application (Layerfile's are similar to Dockerfiles). 
+
+To deploy your application on webapp.io, create a Layerfile and add it to your project repository. To learn how to build a Layerfile, refer to our docs on <a href="/layerfile-reference/what-are-layerfiles">Layerfiles</a>.
+
+### Commit your Layerfile to your repository
+
+Once you've created a Layerfile for your project, add the Layerfile to your project repository and commit it.
+
+Once you've committed your project with the Layerfile, a runner will start to build your application in a virtual machine.
+
+Once the runner has finished building your application, you'll have access to the following:
+
+- Virtual Machine Analytics (CPU, Disk, and Memory)
+- Debugging Terminal (to SSH into your virtual machine) 
+- A preview environment (if your run is successful)
+
+
+### Deploy to your custom domain
+
+Considering you've added a Custom Domain to your webapp.io account and your Layerfile run was successful, you'll have the option to Deploy the virtual machine. 
+
+Deploying the virtual machine will create a new run and will assign the selected Custom Domain to the virtual machine if the run is successful.
+
+Once complete, you can access your project at your domain.

--- a/docs/hosting/introduction.mdx
+++ b/docs/hosting/introduction.mdx
@@ -1,0 +1,27 @@
+---
+title: "Introduction"
+description: "Deploy your project with webapp.io's virtual machines"
+---
+
+<Tip>
+Webapp.io is happy to announce hosting! Deploy your project directly to a virtual machine and connect it to a domain of your choice!
+</Tip>
+
+<Warning>
+To enable webapp.io hosting, please contact our team so we can enable it for your account.
+</Warning>
+
+It's simple to deploy a virtual machine (VM) on webapp.io. To deploy a VM you'll need to <a target="_blank" rel="noreferrer" href="https://webapp.io/sign-up">Sign Up</a> and connect your GitHub account to webapp.io. 
+
+Webapp.io supports multiple languages, so if your stack runs on linux we probably support it. We can also build and deploy anything with a Dockerfile or Docker Compose file. So whether you're running a Node JS, Python, Rails, Ruby, Elixir, Go, or Rust project, we have native support for it.
+
+With webapp.io's deployment via our virtual machines, you get access to the following:
+
+- Free virtual machines
+- Webapp.io's quickstart experience that makes coldstarts feel hot
+- Custom domains (including wildcard domains)
+- Free SSL and Automated Certificate Management for TLS
+- Debugging terminal to debug your virtual machine
+- Virtual machine analytics (CPU, Disk, Memory)
+- Preview environments on every commit
+- Built-in CI/CD

--- a/docs/hosting/tutorial.mdx
+++ b/docs/hosting/tutorial.mdx
@@ -14,5 +14,5 @@ Please make sure you have "Use legacy deployment logic" toggled off in your Orga
 </Note>
 
 <div className="Docs_VideoFrame">
-Video coming soon!
+<iframe width="100%" height="502" src="https://www.youtube.com/embed/pOJJbzknxiY" title="Heroku Alternative: Webapp.io Deployments" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>

--- a/docs/hosting/tutorial.mdx
+++ b/docs/hosting/tutorial.mdx
@@ -1,0 +1,18 @@
+---
+title: "Tutorial"
+description: "Deploy your project with webapp.io's virtual machines"
+---
+
+The video below is a tutorial on how to host your web application with webapp.io. If you have any questions please reach out to our team at <a href="mailto:hello@webapp.io">hello@webapp.io</a>.
+
+<Warning>
+To access the "Deploy" button and the "Deployments" page, please contact our team so we can enable it for your account.
+</Warning>
+
+<Note>
+Please make sure you have "Use legacy deployment logic" toggled off in your Organization Settings.
+</Note>
+
+<div className="Docs_VideoFrame">
+Video coming soon!
+</div>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -133,6 +133,16 @@
       ]
     },
     {
+      "group": "Hosting",
+      "pages": [
+        "hosting/introduction",
+        "hosting/get-started",
+        "hosting/tutorial",
+        "hosting/free-hosting",
+        "hosting/features-and-comparables"
+      ]
+    },
+    {
       "group": "Community",
       "pages": ["community/slack", "community/social-media"]
     },


### PR DESCRIPTION
The docs for webapp.io's new hosting & deployment options. The hosting section includes pages for: 

- Introduction (what webapp.io hosting is)
- Get Started (deploying an example project or your own code)
- Tutorial (A video tutorial on how to use the deployment feature)
- Free hosting (what's included in the free hosting)
- Features and Comparables (features for the VM's + comparables to other services)

NOTE:
Need to upload the webapp.io deployment video to YouTube first before embedding it in the tutorial section